### PR TITLE
#160851565 Make user see old Menus first 

### DIFF
--- a/UI/active-orders.html
+++ b/UI/active-orders.html
@@ -106,10 +106,9 @@
                     </div>
                 </div>
             </div>
-
         </footer>
+        
         <!-- Licencse -->
-
         <div>
             <article id="license">© 2018 Fast Food Fast. All Rights Reserved</article>
         </div>
@@ -163,7 +162,6 @@
             </form>
         </div>
     </div>
-
     <!-- JavaScript -->
     <script type="text/JavaScript" src="js/menu.js"></script>
 </body>

--- a/UI/css/menu.css
+++ b/UI/css/menu.css
@@ -30,7 +30,7 @@
     height: 90%;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap-reverse;
+    flex-wrap: wrap
   }
   
   #description {

--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -505,15 +505,6 @@ span.notMember {
   margin-Right: 0px;
 }
 
-#itemsList {
-  margin: auto;
-  width: 90%;
-  height: 90%;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap-reverse;
-}
-
 #description {
   background-color: rgb(226, 226, 206);
   flex: unset;

--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -1022,6 +1022,7 @@ p.blink {
 
 #informationFields{
   margin-top: 20px;
+  margin-bottom: 170px;
   height: max-content;
   text-align: center
 }

--- a/UI/declined-orders.html
+++ b/UI/declined-orders.html
@@ -64,7 +64,7 @@
     <div id="informationFields">
         <div id="fieldsetA">
             <div id="fieldsetB">DECLINED ORDERS</div>
-            <div id="information">declined orders appears here</div>
+            <div id="information">Declined orders appears here</div>
         </div>
     </div>
 

--- a/UI/js/accepted-orders.js
+++ b/UI/js/accepted-orders.js
@@ -1,11 +1,10 @@
 let message = 'Order Fulfulled';
-var completed = document.querySelectorAll('#completedText');
+let completed = document.querySelectorAll('#completedText');
 completed.forEach(btn => btn.addEventListener('click', function(){
     if (btn.innerHTML == message){
         btn.innerHTML = "Not Delivered";
     } else{
         btn.innerHTML = message;
     }
-    
 }));
 

--- a/UI/js/add-items.js
+++ b/UI/js/add-items.js
@@ -23,7 +23,7 @@ function uploadPicture(input) {
     let file = input.target.files[0];
     var readFile = new FileReader();
 
-    readFile.onload = function (imageFile) {
+    readFile.onload = (imageFile) =>{
         let data = imageFile.target.result;
         showImage.src = data;
         imageArr[lengthI] = data;

--- a/UI/js/add-items.js
+++ b/UI/js/add-items.js
@@ -17,6 +17,7 @@ let itemAdded = [];
 let length = 0;
 let lengthI =0;
 
+//Eventlistener to listen for when a new file is uploaded
 uploadImage.addEventListener('change', uploadPicture);
 function uploadPicture(input) {
     let file = input.target.files[0];

--- a/UI/js/menu.js
+++ b/UI/js/menu.js
@@ -1,8 +1,9 @@
-var addToCartBtn = document.getElementById('addToCartBtn');
-var cartWeight = document.getElementById('cartWeight');
-var cart = cartWeight.innerHTML;
-var click = document.querySelectorAll('#addToCartBtn');
+let addToCartBtn = document.getElementById('addToCartBtn');
+let cartWeight = document.getElementById('cartWeight');
+let cart = cartWeight.innerHTML;
+let click = document.querySelectorAll('#addToCartBtn');
 
+//Increaments the cart number when each individual "add to cart" button is clicked
 click.forEach(btn => btn.addEventListener('click', function(){
   cart = Number(cart);
         cart += 1;

--- a/controller/orders.js
+++ b/controller/orders.js
@@ -1,3 +1,4 @@
+//Import statments
 import storage from '../data/database';
 import model from '../model/order-model';
 
@@ -20,7 +21,7 @@ let pushOrder = (req, res, id) => {
  * @param {*} index - the index of the order being Updated
  * @param {*} id    - orderId associated with the data
  */
-let putOrder = (req, res, index, id) => {
+let putOrder = (req, index, id) => {
     let newOrder = model.populate(req, id);
     storage.database[index] = newOrder;
     return newOrder;
@@ -95,7 +96,7 @@ export default class controller {
             map++;
             if (order.orderId == id) {
                 map--;
-                let state = putOrder(req, res, index, id);
+                let state = putOrder(req, index, id);
                 res.status(200).send({
                     orderId: id,
                     old_Order: oldOrder,

--- a/model/order-model.js
+++ b/model/order-model.js
@@ -1,10 +1,10 @@
-    /**
-     * Stage an instance of required data to be pushed to database 
-     * @param {*} req - incomming json data
-     * @param {*} id  - orderId associated with the data
-    */
-   export default{
-       populate(req, id){
+/**
+ * Stage an instance of required data to be pushed to database 
+ * @param {*} req - incomming json data
+ * @param {*} id  - orderId associated with the data
+*/
+export default {
+    populate(req, id) {
         let newOrder = {
             orderId: id,
             food: req.body.food,
@@ -17,117 +17,125 @@
     }
 }
 
-     export const fullOrder = {
-        "orderId": 1,
-        "food": 'fufu',
-        "quantity": 10,
-        "price": 10,
-        "orderStatus": "uncompleted",
-        "userAddress": "address"
+//Model data for a complete Order
+export const fullOrder = {
+    "orderId": 1,
+    "food": 'fufu',
+    "quantity": 10,
+    "price": 10,
+    "orderStatus": "uncompleted",
+    "userAddress": "address"
+}
 
-    }
+//Model data for an order void of req.body.food
+export const voidFood = {
+    "orderId": 1,
+    "quantity": 10,
+    "price": 10,
+    "orderStatus": "uncompleted",
+    "userAddress": "address"
+}
 
-    export const voidFood= {
-        "orderId": 1,
-        "quantity": 10,
-        "price": 10,
-        "orderStatus": "uncompleted",
-        "userAddress": "address"
-    }
+//Model data for an order void of req.body.price
+export const voidPrice = {
+    "orderId": 1,
+    "food": 'fufu',
+    "quantity": 10,
+    "orderStatus": "uncompleted",
+    "userAddress": "address"
+}
 
-    export const  voidPrice= {
-        "orderId": 1,
-        "food": 'fufu',
-        "quantity": 10,
-        "orderStatus": "uncompleted",
-        "userAddress": "address"
-    }
+//Model data for an order void of req.body.quantity
+export const voidQuantity = {
+    "orderId": 1,
+    "food": 'fufu',
+    "price": 10,
+    "orderStatus": "uncompleted",
+    "userAddress": "address"
+}
 
-    export const voidQuantity= {
-        "orderId": 1,
-        "food": 'fufu',
-        "price": 10,
-        "orderStatus": "uncompleted",
-        "userAddress": "address"
-    }
+//Model data for an order void of req.body.orderStatus
+export const voidOrderStatus = {
+    "orderId": 1,
+    "food": 'fufu',
+    "quantity": 10,
+    "price": 10,
+    "userAddress": "address"
+}
 
-    export const voidOrderStatus={
-        "orderId": 1,
-        "food": 'fufu',
-        "quantity": 10,
-        "price": 10,
-        "userAddress": "address"
-    }
+//Model data for an order void of req.body.userAddress
+export const voidUserAddress = {
+    "orderId": 1,
+    "food": 'fufu',
+    "quantity": 10,
+    "price": 10,
+    "orderStatus": "uncompleted",
+}
 
-    export const voidUserAddress={
-        "orderId": 1,
-        "food": 'fufu',
-        "quantity": 10,
-        "price": 10,
-        "orderStatus": "uncompleted",
-    }
+//Model data for an order void of req.body.orderId
+export const invalidOrderId = {
+    "orderId": 300,
+    "food": 'pizza',
+    "quantity": 10,
+    "price": 9500,
+    "orderStatus": "completed",
+    "userAddress": "address"
+}
 
-    export const invalidOrderId= {
-        "orderId": 300,
-        "food": 'pizza',
-        "quantity": 10,
-        "price": 9500,
-        "orderStatus": "completed",
-        "userAddress": "address"
-    }
-
-    export const databaseOrders = [
-        {
-            "orderId": 0,
-            "food": "peperony pizza",
-            "price": 10,
-            "quantity": 10,
-            "orderStatus": "uncompleted",
-            "userAddress": "Address"
-        },
-        {
-            "orderId": 1,
-            "food": "grilled Chicken",
-            "price": 20,
-            "quantity": 20,
-            "orderStatus": "uncompleted",
-            "userAddress": "Address"
-        }
-    ]
-
-    export const firstOrder = {
+//Instance of the database content
+export const databaseOrders = [
+    {
         "orderId": 0,
         "food": "peperony pizza",
         "price": 10,
         "quantity": 10,
         "orderStatus": "uncompleted",
         "userAddress": "Address"
+    },
+    {
+        "orderId": 1,
+        "food": "grilled Chicken",
+        "price": 20,
+        "quantity": 20,
+        "orderStatus": "uncompleted",
+        "userAddress": "Address"
     }
+]
 
-    export const updatedOrder = [
-        {
-            "orderId": 0,
-            "food": "peperony pizza",
-            "price": 10,
-            "quantity": 10,
-            "orderStatus": "uncompleted",
-            "userAddress": "Address"
-        },
-        {
-            "orderId": 1,
-            "food": "grilled Chicken",
-            "price": 20,
-            "quantity": 20,
-            "orderStatus": "uncompleted",
-            "userAddress": "Address"
-        },
-        {
-            "orderId": 2,
-            "food": 'fufu',
-            "quantity": 10,
-            "price": 10,
-            "orderStatus": "uncompleted",
-            "userAddress": "address"
-        }
-    ]
-    
+//Instance of the database[1]
+export const firstOrder = {
+    "orderId": 0,
+    "food": "peperony pizza",
+    "price": 10,
+    "quantity": 10,
+    "orderStatus": "uncompleted",
+    "userAddress": "Address"
+}
+
+//Instance of the database for push test
+export const updatedOrder = [
+    {
+        "orderId": 0,
+        "food": "peperony pizza",
+        "price": 10,
+        "quantity": 10,
+        "orderStatus": "uncompleted",
+        "userAddress": "Address"
+    },
+    {
+        "orderId": 1,
+        "food": "grilled Chicken",
+        "price": 20,
+        "quantity": 20,
+        "orderStatus": "uncompleted",
+        "userAddress": "Address"
+    },
+    {
+        "orderId": 2,
+        "food": 'fufu',
+        "quantity": 10,
+        "price": 10,
+        "orderStatus": "uncompleted",
+        "userAddress": "address"
+    }
+]

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,7 +1,10 @@
+//Import statements
 import express from 'express';
 import controller from '../controller/orders'
 import validation from '../middleware/validation'
 const router = express.Router();
+
+//creates an instance of the imported controller class
 const Controller = new controller(); 
 
 // Routes

--- a/test/test.js
+++ b/test/test.js
@@ -92,7 +92,7 @@ describe('Validate GET Route', () => {
             .expect("Content-type", /json/)
             .expect(function (res) {
                 res.body.success = 'true';
-                res.body.Status  = "Orders retrieved successfully";
+                res.body.Status = "Orders retrieved successfully";
                 res.body.orders = test.databaseOrders;
             })
             .expect(200, end)
@@ -102,7 +102,7 @@ describe('Validate GET Route', () => {
             .expect("Content-type", /json/)
             .expect(function (res) {
                 res.body.success = 'true';
-                res.body.Status  = "Orders retrieved successfully";
+                res.body.Status = "Orders retrieved successfully";
                 res.body.orders = test.firstOrder;
             })
             .expect(200, end)
@@ -121,7 +121,7 @@ describe('Validate PUT Route', () => {
             request(app).put('/api/v1/orders/0')
                 .type('JSON').send(test.fullOrder)
                 .expect(function (res) {
-                    res.body.Status  = "Update successful";
+                    res.body.Status = "Update successful";
                 })
                 .expect(200, end)
         });


### PR DESCRIPTION
#### What does this PR do?
The pull request fixes the menu section making user see old menus first 

#### Description of Task to be completed?
- Change flex-wrap feature from `wrap-reverse` to `wrap`
- Rearrange the U.I such that old orders appears first while new orders are populated below as the list is updated

#### How should this be manually tested?
- clone the branch
- run `npm init`
- locate the UI folder
- launch the `menu.html` file in the browser

#### What are the relevant pivotal tracker stories?
#160851565

#### Screenshots
![screenshot_3](https://user-images.githubusercontent.com/25525765/46245287-38a30380-c3e3-11e8-85f8-a3c8f578eadb.jpg)

